### PR TITLE
-correccion de dependencias para poder testear a jetpackcompose

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,7 +93,6 @@ dependencies {
     kapt libs.glideCompiler
 
     implementation libs.navigationCompose
-    implementation libs.robolectric
 
     implementation libs.daggerHilt
     kapt libs.daggerHiltCompiler

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,7 +58,6 @@ daggerHilt = { module = "com.google.dagger:hilt-android", version.ref = "daggerH
 daggerHiltCompiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "daggerHilt" }
 daggerHiltTesting = { module = "com.google.dagger:hilt-android-testing", version.ref = "daggerHilt" }
 hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "navigationHilt" }
-robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "androidApplication" }


### PR DESCRIPTION
- se realizo porque se importaba roboelectric innecesariamente